### PR TITLE
New capabilities; buffering; scheduling

### DIFF
--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -167,10 +167,6 @@ def subscribeToEvents() {
 	if (waterSensors != null) {
 		subscribe(waterSensors, "water", genericHandler)
 	}
-
-	if (canSchedule()) {
-		runEvery15Minutes(flushBuffer())
-	}
 }
 
 def getAccessKey() {
@@ -234,6 +230,8 @@ def installed() {
 	atomicState.isBucketCreated = false
 	atomicState.grokerSubdomain = "groker"
 	atomicState.eventBuffer = [];
+
+	runEvery15Minutes(flushBuffer)
 
 	log.debug "installed (version $atomicState.version)"
 }
@@ -317,7 +315,8 @@ def genericHandler(evt) {
 // This is a handler function for flushing the event buffer
 // after a specified amount of time to reduce the load on ST servers
 def flushBuffer() {
-	if (atomicState.eventBuffer.size() > 0) {
+	log.trace "About to flush the buffer on schedule"
+	if (atomicState.eventBuffer != null && atomicState.eventBuffer.size() > 0) {
 		shipEvents();
 	}
 }

--- a/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
+++ b/smartapps/initialstate-events/initial-state-event-streamer.src/initial-state-event-streamer.groovy
@@ -280,7 +280,7 @@ def createBucket() {
 
 	try {
 		// Create a bucket on Initial State so the data has a logical grouping
-		httpPostJson(bucketCreatePost) { resp =>
+		httpPostJson(bucketCreatePost) { resp ->
 			log.debug "bucket posted"
 			if (resp.status >= 400) {
 				log.error "bucket not created successfully"
@@ -353,7 +353,7 @@ def shipEvents() {
 
 	try {
 		// post the events to initial state
-		httpPostJson(eventPost) { resp =>
+		httpPostJson(eventPost) { resp ->
 			log.debug "shipped events and got ${resp.status}"
 			if (resp.status >= 400) {
 				log.error "shipping failed... ${resp.data}"


### PR DESCRIPTION
This pull request contains major enhancements to the Initial State Event Streamer.
Enhancements regarding ST's request for less network resource usage:
- Events are now buffered using `atomicState`
- When there are 10 or more events in the `atomicState` buffer, the buffer is flushed and the events are sent to Initial State
- Every 15 minutes a schedule task is triggered to flush the buffer as long as the buffer is not empty. This solves for the case where very few events are being triggered.

Enhancements based on User's feedback and demand:
- Now allows users to subscribe to `capability.energyMeter` and `capability.powerMeter` among many other new capabilities a user can subscribe to

Other Enhancements:
- Switched all uses of `state` to `atomicState` since buffering was required
- Added link to Initial State's terms of service in comments
- Added ability to define the Initial State streaming service's subdomain for better testing
- Added a version to the `atomicState` to help troubleshoot the SmartApp in both logs and state view.
